### PR TITLE
Add version check in publish workflow and update README examples

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,13 @@
-name: Publish
+name: Release CI
 on:
+  pull_request:
+    branches: [main]
   push:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
   publish:
+    name: Check code and release package
     runs-on: ubuntu-latest
 
     permissions:
@@ -57,5 +59,17 @@ jobs:
       - name: Clean coverage report before publish
         run: rm -rf coverage*
 
+      - name: Check if deno.json version was increased
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin main:main
+          PREVIOUS_VERSION=$(jq -r '.version' deno.json)
+          PREVIOUS_VERSION_MAIN=$(git show main:deno.json | jq -r '.version')
+          if [ "$PREVIOUS_VERSION" == "$PREVIOUS_VERSION_MAIN" ]; then
+            echo "Version was not increased. Failing the workflow."
+            exit 1
+          fi
+
       - name: Publish package to JSR (Deno is published by tags webhook)
+        if: github.event_name == 'push'
         run: deno publish

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This function decompresses a text string that was previously compressed and enco
 ```typescript
 import { decompressText } from 'jsr:@lucasliet/textcompress';
 
-const compressedText = '0EhlbGxvLCB3b3JsZCE=';
+const compressedText = 'DQAAANBIZWxsbywgd29ybGQh';
 const decompressedText = decompressText(compressedText);
 
 console.log(decompressedText);
@@ -51,7 +51,7 @@ This function decompresses a string that was previously compressed and encoded i
 ```typescript
 import { decompressObject } from 'jsr:@lucasliet/textcompress';
 
-const compressedObj = '8AB7Im9sYSI6Im11bmRvIn0='; // Insert a lz4 compressed and base64-encoded string here.
+const compressedObj = 'DwAAAPAAeyJvbGEiOiJtdW5kbyJ9'; // Insert a lz4 compressed and base64-encoded string here.
 const decompressedObj = decompressObject(compressedObj);
 
 console.log(decompressedObj);

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucasliet/textcompress",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"license": "MIT",
 	"exports": "./mod.ts",
 	"tasks": {


### PR DESCRIPTION
This pull request introduces updates to the release workflow, documentation, and package versioning. The most notable changes include enhancements to the GitHub Actions workflow for publishing, updates to example code in the `README.md`, and a version bump in `deno.json`.

### Workflow improvements:
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L1-R10): Renamed the workflow to "Release CI," added a `pull_request` trigger for the `main` branch, and updated the job name to "Check code and release package."  
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R62-R74): Added a step to verify that the `deno.json` version is incremented in pull requests and restricted the "Publish package" step to only run on `push` events.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28): Updated the example `compressedText` string in the `decompressText` function to reflect a new base64-encoded value.  
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R54): Updated the example `compressedObj` string in the `decompressObject` function to reflect a new base64-encoded value.

### Version update:
* [`deno.json`](diffhunk://#diff-54337bcff4b919f6b8b4e0b0e51d06fd9124562fde88899be726c24b7e354b7cL3-R3): Incremented the package version from `3.0.0` to `3.0.1`.Implement a version check for `deno.json` in the publish workflow to ensure the version is incremented before publishing. Update example compressed strings in the README for clarity.